### PR TITLE
Patch reverse selection

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -4,28 +4,28 @@ var window = vscode.window;
 function activate(context) {
 
     var disposable = vscode.commands.registerCommand('extension.pasteAndFormat', function () {
-        
-        
+
+
         //Check if current document is markdown
-        
+
         if(window.activeTextEditor.document.languageId === 'markdown'){
             vscode.commands.executeCommand('workbench.action.markdown.togglePreview');
         } else {
             // Save current position
-            var start = window.activeTextEditor.selection.anchor;
+            var start = window.activeTextEditor.selection.active;
             // Paste from clipboard
             vscode.commands.executeCommand('editor.action.clipboardPasteAction').then(function () {
 
-                var end = window.activeTextEditor.selection.anchor; // Get position after paste
+                var end = window.activeTextEditor.selection.active; // Get position after paste
                 var selection = new vscode.Selection(start.line, start.character, end.line, end.character); // Create selection
                 window.activeTextEditor.selection = selection; // Apply selection to editor
-                
+
                 // Format selection, when text is selected, that text is the only thing that will be formatted
                 vscode.commands.executeCommand('editor.action.format').then(function () {
                     // This is where I really would like the deselection to happen but it runs before
                     // formatting is done, I've tried window.onDidChangeTextEditorSelection, but that doesn't
                     // seem to work how I would like it to eighther.
-                    // Until issue #1775 is solved I just use a timeout. 
+                    // Until issue #1775 is solved I just use a timeout.
 
                     setTimeout(function () {
                         // Hopefully the format command is done when this happens
@@ -38,10 +38,10 @@ function activate(context) {
 
                 });
 
-            });            
+            });
         }
-        
-       
+
+
 
     });
 

--- a/extension.js
+++ b/extension.js
@@ -4,10 +4,10 @@ var window = vscode.window;
 function activate(context) {
 
     var disposable = vscode.commands.registerCommand('extension.pasteAndFormat', function () {
-
-
+        
+        
         //Check if current document is markdown
-
+        
         if(window.activeTextEditor.document.languageId === 'markdown'){
             vscode.commands.executeCommand('workbench.action.markdown.togglePreview');
         } else {
@@ -19,13 +19,13 @@ function activate(context) {
                 var end = window.activeTextEditor.selection.active; // Get position after paste
                 var selection = new vscode.Selection(start.line, start.character, end.line, end.character); // Create selection
                 window.activeTextEditor.selection = selection; // Apply selection to editor
-
+                
                 // Format selection, when text is selected, that text is the only thing that will be formatted
                 vscode.commands.executeCommand('editor.action.format').then(function () {
                     // This is where I really would like the deselection to happen but it runs before
                     // formatting is done, I've tried window.onDidChangeTextEditorSelection, but that doesn't
                     // seem to work how I would like it to eighther.
-                    // Until issue #1775 is solved I just use a timeout.
+                    // Until issue #1775 is solved I just use a timeout. 
 
                     setTimeout(function () {
                         // Hopefully the format command is done when this happens
@@ -38,10 +38,10 @@ function activate(context) {
 
                 });
 
-            });
+            });            
         }
-
-
+        
+       
 
     });
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pasteandformat",
 	"displayName": "pasteandformat",
 	"description": "Paste and format with one command",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"publisher": "spoeken",
 	"engines": {
 		"vscode": "^0.10.1"
@@ -22,7 +22,7 @@
             "when": "editorTextFocus"
         }]
 	},
-    
+
 	"devDependencies": {
 		"vscode": "0.10.x"
 	}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
             "when": "editorTextFocus"
         }]
 	},
-
+    
 	"devDependencies": {
 		"vscode": "0.10.x"
 	}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pasteandformat",
 	"displayName": "pasteandformat",
 	"description": "Paste and format with one command",
-	"version": "0.0.5",
+	"version": "0.0.4",
 	"publisher": "spoeken",
 	"engines": {
 		"vscode": "^0.10.1"


### PR DESCRIPTION
Fixes an issue when overwriting text selected from the bottom up.

When pasting over text selected text, the newly pasted text would not be formatted correctly. This was due to the cursor position being located using TextEditor.selection.achor which does not indicate the position of the cursor, but rather where the text selection had started (https://code.visualstudio.com/docs/extensionAPI/vscode-api#Selection). TextEditor.selection.active should have been used.
